### PR TITLE
Verify custom rules are preserved

### DIFF
--- a/test/compiler.js
+++ b/test/compiler.js
@@ -11,7 +11,7 @@ import { expect } from 'chai';
  *
  * @return { Promise<{ output: string, stats: import('webpack').Stats }> }
  */
-export async function compile(entry, plugins) {
+export async function compile(entry, plugins, rules = []) {
 
   const {
     fs
@@ -27,7 +27,10 @@ export async function compile(entry, plugins) {
     },
     plugins: [
       ...plugins
-    ]
+    ],
+    module: {
+      rules
+    }
   });
 
   compiler.outputFileSystem = fs;

--- a/test/spec/CamundaModelerWebpackPlugin.spec.js
+++ b/test/spec/CamundaModelerWebpackPlugin.spec.js
@@ -70,4 +70,28 @@ describe('<CamundaModelerWebpackPlugin>', function() {
     throw new Error('this should not happen');
   });
 
+
+  it('should preserve custom rule', async function() {
+
+    // given
+    const entry = './fixtures/client-extension/index.js';
+
+    const styleRule = {
+      test: /\.css/,
+      exclude: /node_modules/,
+      use: {
+        loader: 'style-loader'
+      }
+    };
+
+    // when
+    const { stats } = await compile(entry, [ new CamundaModelerWebpackPlugin({
+      'type': 'react'
+    }) ], [ styleRule ]);
+
+    // then
+    // style rule is preserved
+    expect(stats.compilation.options.module.rules).to.include(styleRule);
+  });
+
 });


### PR DESCRIPTION
### Proposed Changes
This PR aims to add following test cases in addition to PR #8 . 

- before and after webpack plugin applies
- ~~should have alias when plugin applies~~
- you can apply custom rules 
    - can work with plugins 
    - can work without plugins

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
