### PR TITLE
Transform `@carbon/icons-react`

### DIFF
--- a/test/compiler.mjs
+++ b/test/compiler.mjs
@@ -101,6 +101,7 @@ const CONFIG_PROPERTIES_PANEL_ALIAS = [ '@bpmn-io/properties-panel', 'camunda-mo
 const CONFIG_BPMN_JS_PROPERTIES_PANEL_ALIAS = [ 'bpmn-js-properties-panel', 'camunda-modeler-plugin-helpers/vendor/bpmn-js-properties-panel' ];
 const CONFIG_REACT_ALIAS = [ 'react', 'camunda-modeler-plugin-helpers/vendor/react' ];
 const CONFIG_CARBON_REACT_ALIAS = [ '@carbon/react', 'camunda-modeler-plugin-helpers/vendor/@carbon/react' ];
+const CONFIG_CARBON_ICONS_REACT_ALIAS = [ '@carbon/icons-react', 'camunda-modeler-plugin-helpers/vendor/@carbon/icons-react' ];
 
 
 export function configuredReactAlias(stats) {
@@ -120,5 +121,5 @@ export function configuredBabelLoader(stats) {
 }
 
 export function configuredCarbonReactAlias(stats) {
-  return configuredAlias(stats, CONFIG_CARBON_REACT_ALIAS);
+  return configuredAlias(stats, CONFIG_CARBON_REACT_ALIAS) && configuredAlias(stats, CONFIG_CARBON_ICONS_REACT_ALIAS);
 }

--- a/test/spec/carbon-react.spec.mjs
+++ b/test/spec/carbon-react.spec.mjs
@@ -80,8 +80,11 @@ describe('<type = carbon-react>', function() {
     // then
     expectNoErrors(stats);
 
-    expect(output).not.to.include("import React, { Fragment, Component } from 'react'");
+    expect(output).not.to.include("import { IconButton } from '@carbon/react'");
     expect(output).to.include('"../node_modules/camunda-modeler-plugin-helpers/vendor/@carbon/react.js"');
+
+    expect(output).not.to.include("import { Add } from '@carbon/icons-react'");
+    expect(output).to.include('"../node_modules/camunda-modeler-plugin-helpers/vendor/@carbon/icons-react.js"');
   });
 
 


### PR DESCRIPTION
Related to: https://github.com/camunda/camunda-modeler-webpack-plugin/pull/5, https://github.com/camunda/camunda-modeler-webpack-plugin/pull/5#discussion_r2192151431

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

We missed the alias checking for `icons-react`. This PR added that check. 


### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
